### PR TITLE
filename ext not support bug

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -203,10 +203,13 @@ func testProgram(c *cli.Context) {
 	file := c.Args().First()
 	pid, _, ext := parseFilename(file)
 
-	// compile source code
 	loadConfig()
+	if config.Test[ext].Run == nil {
+		panic("file type not supported, please add compile and run commands to config.yml")
+	}
+
 	compile := renderCmd(config.Test[ext].Compile, file)
-	// for non-script languages
+	// compile source code for non-script languages
 	if compile != nil {
 		stop := spin("Compiling")
 		out, err := compile.CombinedOutput()

--- a/config.yml
+++ b/config.yml
@@ -3,6 +3,10 @@ test:
     compile: [g++, -Wall, -fdiagnostics-color=always, -O2, '{}']
     run: [./a.out]
 
+  cpp:
+    compile: [g++, -Wall, -fdiagnostics-color=always, -O2, '{}']
+    run: [./a.out]
+
   c:
     compile: [gcc, -Wall, -fdiagnostics-color=always, -O2, '{}']
     run: [./a.out]

--- a/helpers.go
+++ b/helpers.go
@@ -35,7 +35,7 @@ var filename = regexp.MustCompile(`(\d+)\.([\w-]+)\.(\w+)`)
 func parseFilename(s string) (pid int, name string, ext string) {
 	match := filename.FindStringSubmatch(s)
 	if len(match) != 4 {
-    panic("filename pattern does not match. help: please create file with `uva touch` command")
+		panic("filename pattern does not match. help: please create file with `uva touch` command")
 	}
 	pid, err := strconv.Atoi(match[1])
 	if err != nil {


### PR DESCRIPTION
```
uva test 1.xxx.ccc
```

when I use a file ext that doesn't support, program will throw "Invalid memory address or nil pointer dereference
" error, it is because ext name doesn't in config.